### PR TITLE
add -y to apt install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ sudo apt update
 
 echo "Installing Node.js ..."
 if [ "`dpkg -s nodejs | grep "installed"`" = "" ]; then
-  sudo apt install nodejs
+  sudo apt install nodejs -y
   echo "Configuring Node.js ..."
   sudo ln -s /usr/bin/nodejs /usr/bin/node
   echo "Node.js installed!"
@@ -20,7 +20,7 @@ fi
 
 echo "Installing npm ..."
 if [ "`dpkg -s npm | grep "installed"`" = "" ]; then
-  sudo apt install npm
+  sudo apt install npm -y
   echo "npm installed!"
 else
   echo "npm is already installed!";


### PR DESCRIPTION
Current the install script would prompt the user to enter `y` or `n` to install a package. Passing the flag `-y` will automatically install the package.